### PR TITLE
Fix local signal duplicate tracking price normalization

### DIFF
--- a/tests/test_signal_queue_execution.py
+++ b/tests/test_signal_queue_execution.py
@@ -197,7 +197,8 @@ class TestSignalQueueExecution:
         assert not allowed_again
         assert 'cooldown' in reason_again.lower()
         assert engine._local_last_signal_time
-        assert engine._local_signal_price_history['BTC/USDT:USDT']
+        history_key = 'BTC/USDT:USDT:test_strategy'
+        assert engine._local_signal_price_history[history_key]
 
     async def _queue_priority_over_scanning(self):
         """


### PR DESCRIPTION
## Summary
- normalize incoming signal entry prices before duplicate-prevention checks
- scope local signal price history per strategy to avoid cross-strategy interference
- add safe handling for zero/invalid prices and adjust duplicate tracking test

## Testing
- PYENV_VERSION=3.11.12 pytest tests/test_signal_queue_execution.py -k record_local_signal -vv

------
https://chatgpt.com/codex/tasks/task_e_68f81786d6148324977523e6bf78bfee