### PR TITLE
Add devcontainer configuration for Python 3.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
   "name": "Bearish Alpha Bot",
   "features": {
     "ghcr.io/devcontainers/features/python": {
-      "version": "3.11"
+      "version": "~3.11.0"
     }
   },
-  "postCreateCommand": "python --version"
+  "postCreateCommand": "python --version && python -c 'import sys; assert sys.version_info[:2] == (3, 11), \"Python 3.11 required\"' && if [ -f requirements.txt ]; then pip install -r requirements.txt; fi"
 }


### PR DESCRIPTION
## Summary
- add a devcontainer configuration so Codespaces/Copilot Workspace start with Python 3.11
- run python --version after container creation for quick visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa59aa1eb083248ee4e3dee68c359e