### PR TITLE
Fix: Add DEFAULT_TIMEOUT to ccxt_client and use in requests

### DIFF
--- a/src/core/ccxt_client.py
+++ b/src/core/ccxt_client.py
@@ -32,6 +32,7 @@ EX_DEFAULTS = {
     "verify": False  # Disable SSL verification (for GitHub Actions environment)
 }
 
+DEFAULT_TIMEOUT = 10
 
 class CcxtClient:
     def __init__(self, ex_name: str, creds: dict | None = None):
@@ -470,7 +471,7 @@ class CcxtClient:
         """Get official KuCoin server timestamp with local fallback."""
         try:
             url = "https://api-futures.kucoin.com/api/v1/timestamp"
-            response = requests.get(url, timeout=5)
+            response = requests.get(url, timeout=DEFAULT_TIMEOUT)
             response.raise_for_status()
             
             server_data = response.json()
@@ -492,7 +493,7 @@ class CcxtClient:
         """Get official BingX server timestamp with local fallback."""
         try:
             url = "https://open-api.bingx.com/openApi/swap/v2/server/time"
-            response = requests.get(url, timeout=5)
+            response = requests.get(url, timeout=DEFAULT_TIMEOUT)
             response.raise_for_status()
             
             server_data = response.json()
@@ -522,7 +523,7 @@ class CcxtClient:
             
         try:
             url = "https://api-futures.kucoin.com/api/v1/contracts/active"
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, timeout=DEFAULT_TIMEOUT)
             response.raise_for_status()
             
             contracts_data = response.json()
@@ -574,7 +575,7 @@ class CcxtClient:
         try:
             # BingX public endpoint - authentication gerekmez
             url = "https://open-api.bingx.com/openApi/swap/v2/quote/contracts"
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, timeout=DEFAULT_TIMEOUT)
             response.raise_for_status()
             
             data = response.json()


### PR DESCRIPTION
This pull request standardizes the timeout value for all HTTP requests made in the `CcxtClient` class by introducing a single `DEFAULT_TIMEOUT` constant. This improves maintainability and consistency across the codebase.

**Timeout standardization:**

* Added a `DEFAULT_TIMEOUT` constant set to 10 seconds in `src/core/ccxt_client.py` to unify HTTP request timeout settings.
* Updated the timeout parameter in all `requests.get` calls within private methods (`_get_kucoin_server_time`, `_get_bingx_server_time`, `_get_dynamic_symbol_mapping`, `_get_bingx_contracts`) to use `DEFAULT_TIMEOUT` instead of hardcoded values. [[1]](diffhunk://#diff-6de40d61b06383c2459db4d5ec91bc6fa15c0d2cb7594660fea96be4c55b02c5L473-R474) [[2]](diffhunk://#diff-6de40d61b06383c2459db4d5ec91bc6fa15c0d2cb7594660fea96be4c55b02c5L495-R496) [[3]](diffhunk://#diff-6de40d61b06383c2459db4d5ec91bc6fa15c0d2cb7594660fea96be4c55b02c5L525-R526) [[4]](diffhunk://#diff-6de40d61b06383c2459db4d5ec91bc6fa15c0d2cb7594660fea96be4c55b02c5L577-R578)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized timeout configuration across API connections for improved consistency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->